### PR TITLE
Add catching of Plonk extra G1 elements

### DIFF
--- a/conversion/src/main.rs
+++ b/conversion/src/main.rs
@@ -16,7 +16,7 @@ use std::{fmt::Error, fs, fs::File, io::Write};
 const FILE_MAX_TAU_POWERS: usize = 1 << 21;
 
 // The maximum number of tau powers needed for Dusk Blockchain circuits
-const DUSK_MAX_TAU_POWERS: usize = 1 << 17;
+const DUSK_MAX_TAU_POWERS: usize = (1 << 17) + 6; // + 6 due to blinding factors
 
 // The size of G1 affine points in compressed form
 const G1_AFFINE_COMPRESSED_SIZE: usize = 48;
@@ -34,7 +34,7 @@ fn main() -> Result<(), Error> {
     let mut powers_of_tau_g1: Vec<u8> = vec![];
     let mut it_size = 64; // We start at 64 since the response included a hash at the beginning
 
-    for _ in 0..DUSK_MAX_TAU_POWERS {
+    for _ in 0..=DUSK_MAX_TAU_POWERS {
         powers_of_tau_g1
             .extend_from_slice(&response_bytes[it_size..it_size + G1_AFFINE_COMPRESSED_SIZE]);
         it_size += G1_AFFINE_COMPRESSED_SIZE;


### PR DESCRIPTION
This PR fixes the way how the powers of tau are taken for `dusk_plonk`. Only `2^n` (`n` being the circuit size) elements were taken, but Plonk needs `n + 5` elements by definition. In our particular case, `n + 6` due to blinding factors.